### PR TITLE
Add SimpleUDPServerHandler to handle UDP packets

### DIFF
--- a/core/src/main/java/com/avolution/net/udp/SimpleUDPServerHandler.java
+++ b/core/src/main/java/com/avolution/net/udp/SimpleUDPServerHandler.java
@@ -1,0 +1,26 @@
+package com.avolution.net.udp;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+public class SimpleUDPServerHandler extends SimpleChannelInboundHandler<UDPPacket> {
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, UDPPacket packet) {
+        System.out.println("Received packet:");
+        System.out.println("Sequence Number: " + packet.getSequenceNumber());
+        System.out.println("Acknowledgment Number: " + packet.getAcknowledgmentNumber());
+        System.out.println("Content: " + new String(packet.getContent()));
+
+        // Handle the packet content and send a response
+        String responseContent = "Response to Sequence Number " + packet.getSequenceNumber();
+        UDPPacket responsePacket = new UDPPacket(packet.getSequenceNumber(), packet.getAcknowledgmentNumber(), responseContent.getBytes());
+        ctx.writeAndFlush(responsePacket);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        cause.printStackTrace();
+        ctx.close();
+    }
+}

--- a/core/src/test/java/com/avolution/net/udp/UDPNettyServiceTest.java
+++ b/core/src/test/java/com/avolution/net/udp/UDPNettyServiceTest.java
@@ -49,4 +49,16 @@ class UDPNettyServiceTest {
         UDPPacket packet = new UDPPacket(1, 0, content);
         // Add logic to simulate outgoing packet and verify handling
     }
+
+    @Test
+    void testSimpleUDPServerHandler() {
+        SimpleUDPServerHandler handler = new SimpleUDPServerHandler();
+        byte[] content = "Test packet".getBytes();
+        UDPPacket packet = new UDPPacket(1, 0, content);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+
+        handler.channelRead0(ctx, packet);
+
+        verify(ctx, times(1)).writeAndFlush(any(UDPPacket.class));
+    }
 }


### PR DESCRIPTION
Implement `SimpleUDPServerHandler` to handle UDP packets in `UDPNettyService`.

* **SimpleUDPServerHandler.java**
  - Create `SimpleUDPServerHandler` class extending `SimpleChannelInboundHandler<UDPPacket>`.
  - Override `channelRead0` method to log packet details and send a response packet.
  - Implement `exceptionCaught` method to handle exceptions.

* **UDPNettyServiceTest.java**
  - Add `testSimpleUDPServerHandler` to verify packet handling by `SimpleUDPServerHandler`.
  - Mock `ChannelHandlerContext` and verify response packet is sent.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zerosoft/avolution?shareId=26fcf310-1593-4988-be92-00999cdbc95c).