### PR TITLE
Fix UDP encryption type method

### DIFF
--- a/core/src/main/java/com/avolution/net/udp/UDPPacket.java
+++ b/core/src/main/java/com/avolution/net/udp/UDPPacket.java
@@ -5,11 +5,13 @@ import com.avolution.net.MessagePacket;
 public class UDPPacket extends MessagePacket {
     private int sequenceNumber; // 序列号
     private int acknowledgmentNumber; // 确认号
+    private int encryptionType; // 加密类型
 
     public UDPPacket(int sequenceNumber, int acknowledgmentNumber, byte[] content) {
         super(8 + content.length, content); // 2个int类型的字段共8字节，加上包体内容长度
         this.sequenceNumber = sequenceNumber;
         this.acknowledgmentNumber = acknowledgmentNumber;
+        this.encryptionType = 0; // 默认加密类型
     }
 
     public int getSequenceNumber() {
@@ -20,11 +22,19 @@ public class UDPPacket extends MessagePacket {
         return acknowledgmentNumber;
     }
 
+    public int getEncryptionType() {
+        return encryptionType;
+    }
+
     public void setSequenceNumber(int sequenceNumber) {
         this.sequenceNumber = sequenceNumber;
     }
 
     public void setAcknowledgmentNumber(int acknowledgmentNumber) {
         this.acknowledgmentNumber = acknowledgmentNumber;
+    }
+
+    public void setEncryptionType(int encryptionType) {
+        this.encryptionType = encryptionType;
     }
 }


### PR DESCRIPTION
Add `getEncryptionType()` method to `UDPPacket` class.

* Add `encryptionType` field to `UDPPacket` class.
* Add `getEncryptionType()` method to return the `encryptionType` field.
* Add `setEncryptionType()` method to set the `encryptionType` field.
* Initialize `encryptionType` field to 0 in the `UDPPacket` constructor.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zerosoft/avolution?shareId=4c972cf7-b1f4-4b67-992e-d038b3c99c9a).