### PR TITLE
Fix ActorRefProxy destroy method

### DIFF
--- a/core/src/main/java/com/avolution/actor/context/ActorContext.java
+++ b/core/src/main/java/com/avolution/actor/context/ActorContext.java
@@ -153,12 +153,16 @@ public class ActorContext {
     public void stop() {
         if (state.compareAndSet(LifecycleState.STARTED, LifecycleState.STOPPING)) {
             self.get().postStop();
+            ActorRefProxy<?> proxy = (ActorRefProxy<?>) self.get().getSelf();
+            proxy.destroy();
             state.set(LifecycleState.STOPPED);
         }
     }
 
     public void stop(ActorRef actorRef){
-
+        if (actorRef instanceof ActorRefProxy) {
+            ((ActorRefProxy<?>) actorRef).destroy();
+        }
     }
 
     public ActorContext getParent() {

--- a/core/src/main/java/com/avolution/actor/core/AbstractActor.java
+++ b/core/src/main/java/com/avolution/actor/core/AbstractActor.java
@@ -134,7 +134,7 @@ public abstract class AbstractActor<T> implements ActorRef<T>, MessageHandler<T>
     }
     // 生命周期回调方法
     public void postStop() {
-
+        destroy();
     }
 
     public void preRestart(Throwable reason) {
@@ -202,5 +202,10 @@ public abstract class AbstractActor<T> implements ActorRef<T>, MessageHandler<T>
 
     public <R> CompletableFuture<R> ask(T message) {
         return ask(message, Duration.ofSeconds(5)); // 默认5秒超时
+    }
+
+    public void destroy() {
+        // Notify ActorRefProxy to release the reference
+        getSelf().tell(null, ActorRef.noSender());
     }
 }

--- a/core/src/main/java/com/avolution/actor/core/ActorRefProxy.java
+++ b/core/src/main/java/com/avolution/actor/core/ActorRefProxy.java
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletableFuture;
  */
 public class ActorRefProxy<T> implements ActorRef<T> {
 
-    private final AbstractActor<T> actor;
+    private AbstractActor<T> actor;
 
     public ActorRefProxy(AbstractActor<T> actor) {
         this.actor = actor;
@@ -37,5 +37,9 @@ public class ActorRefProxy<T> implements ActorRef<T> {
     @Override
     public boolean isTerminated() {
         return actor.isTerminated();
+    }
+
+    public void destroy() {
+        actor = null;
     }
 }


### PR DESCRIPTION
Add destroy method to AbstractActor and ActorRefProxy to release references when actor is destroyed.

* **AbstractActor.java**
  - Add `destroy` method to notify `ActorRefProxy` to release the reference.
  - Call `destroy` method in `postStop` method.

* **ActorRefProxy.java**
  - Change `actor` field to non-final.
  - Add `destroy` method to set `actor` reference to null.

* **ActorContext.java**
  - Call `destroy` method on `ActorRefProxy` when `AbstractActor` is destroyed in `stop` method.
  - Ensure `destroy` method is called in `stop(ActorRef actorRef)` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zerosoft/avolution/pull/28?shareId=4cfde84a-5d65-4c97-8076-fb22cd2d7a4c).